### PR TITLE
Clarify metric names in task documentation

### DIFF
--- a/tasks/flat-compression/index.md
+++ b/tasks/flat-compression/index.md
@@ -15,8 +15,8 @@ In this task, the time taken to serialize and deserialize the data is not consid
 
 ### Metrics
 
-- The primary metric is the serialized representation size of the RDF data, in bytes.
-- Additionally, the compression ratio can be calculated as the ratio of the reference size to the compressed size. The reference size is the size of the same data serialized using a baseline method, e.g., the N-Triples serialization format.
+- **Serialized representation size** – the primary metric, size of the serialized RDF data, in bytes.
+- **Compression ratio** – additionally, the compression ratio can be calculated as the ratio of the reference size to the compressed size. The reference size is the size of the same data serialized using a baseline method, e.g., the N-Triples serialization format.
     - In the RDF literature, the "compression ratio" is often defined as the inverse of the above definition and expressed as a percentage. For example, a compression ratio of (50%) means that the compressed data is half the size of the reference data.
 
 ## Results

--- a/tasks/flat-deserialization-throughput/index.md
+++ b/tasks/flat-deserialization-throughput/index.md
@@ -17,7 +17,7 @@ The task consists of deserializing serialized RDF data stored in memory to a fla
 
 ### Metrics
 
-The primary metric is the throughput of the deserialization process, measured in RDF statements (triples or quads) per second. This is calculated as the total number of RDF statements deserialized divided by the total time taken to deserialize them.
+- **Deserialization throughput** – the primary metric, measured in RDF statements (triples or quads) per second. This is calculated as the total number of RDF statements deserialized divided by the total time taken to deserialize them.
 
 
 ## Results

--- a/tasks/flat-serialization-throughput/index.md
+++ b/tasks/flat-serialization-throughput/index.md
@@ -18,7 +18,7 @@ The task consists of serializing RDF data stored in memory (as an array of RDF s
 
 ### Metrics
 
-The primary metric is the throughput of the serialization process, measured in RDF statements (triples or quads) per second. This is calculated as the total number of RDF statements serialized divided by the total time taken to serialize them.
+- **Serialization throughput** – the primary metric, measured in RDF statements (triples or quads) per second. This is calculated as the total number of RDF statements serialized divided by the total time taken to serialize them.
 
 ## Results
 


### PR DESCRIPTION
This is to match the convenient style used in the task flat-rdf-store-loading.